### PR TITLE
Add from string templates with functions

### DIFF
--- a/multitemplate.go
+++ b/multitemplate.go
@@ -49,6 +49,18 @@ func (r *Render) AddFromString(name, templateString string) *template.Template {
 	return tmpl
 }
 
+// AddFromStringsFuncs supply add template from strings
+func (r *Render) AddFromStringsFuncs(name string, funcMap template.FuncMap, templateStrings ...string) *template.Template {
+	tmpl := template.New(name).Funcs(funcMap)
+
+	for _, ts := range templateStrings {
+		tmpl = template.Must(tmpl.Parse(ts))
+	}
+
+	r.Add(name, tmpl)
+	return tmpl
+}
+
 // AddFromFilesFuncs supply add template from file callback func
 func (r Render) AddFromFilesFuncs(name string, funcMap template.FuncMap, files ...string) *template.Template {
 	tname := filepath.Base(files[0])

--- a/multitemplate_test.go
+++ b/multitemplate_test.go
@@ -38,6 +38,13 @@ func createFromString() Render {
 	return r
 }
 
+func createFromStringsWithFuncs() Render {
+	r := New()
+	r.AddFromStringsFuncs("index", template.FuncMap{}, `Welcome to {{ .name }} {{template "content"}}`, `{{define "content"}}template{{end}}`)
+
+	return r
+}
+
 func TestMissingTemplateOrName(t *testing.T) {
 	r := New()
 	tmpl := template.Must(template.New("test").Parse("Welcome to {{ .name }} template"))
@@ -81,6 +88,20 @@ func TestAddFromGlob(t *testing.T) {
 func TestAddFromString(t *testing.T) {
 	router := gin.New()
 	router.HTMLRender = createFromString()
+	router.GET("/", func(c *gin.Context) {
+		c.HTML(200, "index", gin.H{
+			"name": "index",
+		})
+	})
+
+	w := performRequest(router, "GET", "/")
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "Welcome to index template", w.Body.String())
+}
+
+func TestAddFromStringsFruncs(t *testing.T) {
+	router := gin.New()
+	router.HTMLRender = createFromStringsWithFuncs()
 	router.GET("/", func(c *gin.Context) {
 		c.HTML(200, "index", gin.H{
 			"name": "index",


### PR DESCRIPTION
This enable adding multitemplates using strings and passing custom functions to them.

This is useful specially when working with embeded resources managers like go-bindata.