### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,19 +89,19 @@ func main() {
 func loadTemplates(templatesDir string) multitemplate.Render {
 	r := multitemplate.New()
 
-	layouts, err := filepath.Glob(templatesDir + "layouts/*.tmpl")
+	layouts, err := filepath.Glob(templatesDir + "/layouts/*.tmpl")
 	if err != nil {
 		panic(err.Error())
 	}
 
-	includes, err := filepath.Glob(templatesDir + "includes/*.tmpl")
+	includes, err := filepath.Glob(templatesDir + "/includes/*.tmpl")
 	if err != nil {
 		panic(err.Error())
 	}
 
 	// Generate our templates map from our layouts/ and includes/ directories
 	for _, layout := range layouts {
-		files := append(includes, layout)
+		files := append([]string{layout}, includes...)
 		r.Add(filepath.Base(layout), template.Must(template.ParseFiles(files...)))
 	}
 	return r


### PR DESCRIPTION
If you use either AddFromFiles or Add with template.Must(template.ParseFiles(files...)) (i.e. without specified name) ParseFiles method uses first file in the list to create template and it should be the main template (layout).