### PR TITLE
Hot reloading with multitemplates

### DIFF
--- a/dynamic.go
+++ b/dynamic.go
@@ -2,6 +2,7 @@ package multitemplate
 
 import (
 	"html/template"
+	"path/filepath"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/render"
@@ -86,12 +87,14 @@ func (r DynamicRender) Add(name string, tmpl *template.Template) {
 		panic("template name cannot be empty")
 	}
 	builder := &templateBuilder{templateName: name, tmpl: tmpl}
+	builder.buildType = templateType
 	r[name] = builder
 }
 
 // AddFromFiles supply add template from files
 func (r DynamicRender) AddFromFiles(name string, files ...string) *template.Template {
 	builder := &templateBuilder{templateName: name, files: files}
+	builder.buildType = filesTemplateType
 	r[name] = builder
 	return builder.buildTemplate()
 }
@@ -99,6 +102,7 @@ func (r DynamicRender) AddFromFiles(name string, files ...string) *template.Temp
 // AddFromGlob supply add template from global path
 func (r DynamicRender) AddFromGlob(name, glob string) *template.Template {
 	builder := &templateBuilder{templateName: name, glob: glob}
+	builder.buildType = globTemplateType
 	r[name] = builder
 	return builder.buildTemplate()
 }
@@ -106,6 +110,7 @@ func (r DynamicRender) AddFromGlob(name, glob string) *template.Template {
 // AddFromString supply add template from strings
 func (r DynamicRender) AddFromString(name, templateString string) *template.Template {
 	builder := &templateBuilder{templateName: name, templateString: templateString}
+	builder.buildType = stringTemplateType
 	r[name] = builder
 	return builder.buildTemplate()
 }
@@ -114,13 +119,16 @@ func (r DynamicRender) AddFromString(name, templateString string) *template.Temp
 func (r DynamicRender) AddFromStringsFuncs(name string, funcMap template.FuncMap, templateStrings ...string) *template.Template {
 	builder := &templateBuilder{templateName: name, funcMap: funcMap,
 		templateStrings: templateStrings}
+	builder.buildType = stringFuncTemplateType
 	r[name] = builder
 	return builder.buildTemplate()
 }
 
 // AddFromFilesFuncs supply add template from file callback func
 func (r DynamicRender) AddFromFilesFuncs(name string, funcMap template.FuncMap, files ...string) *template.Template {
-	builder := &templateBuilder{templateName: name, funcMap: funcMap, files: files}
+	tname := filepath.Base(files[0])
+	builder := &templateBuilder{templateName: tname, funcMap: funcMap, files: files}
+	builder.buildType = filesFuncTemplateType
 	r[name] = builder
 	return builder.buildTemplate()
 }

--- a/dynamic.go
+++ b/dynamic.go
@@ -1,6 +1,7 @@
 package multitemplate
 
 import (
+	"fmt"
 	"html/template"
 	"path/filepath"
 
@@ -135,8 +136,12 @@ func (r DynamicRender) AddFromFilesFuncs(name string, funcMap template.FuncMap, 
 
 // Instance supply render string
 func (r DynamicRender) Instance(name string, data interface{}) render.Render {
+	builder, ok := r[name]
+	if !ok {
+		panic(fmt.Sprintf("Dynamic template with name %s not found", name))
+	}
 	return render.HTML{
-		Template: r[name].buildTemplate(),
+		Template: builder.buildTemplate(),
 		Data:     data,
 	}
 }

--- a/dynamic.go
+++ b/dynamic.go
@@ -1,0 +1,134 @@
+package multitemplate
+
+import (
+	"html/template"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/render"
+)
+
+// DynamicRender type
+type DynamicRender map[string]*templateBuilder
+
+var (
+	_ render.HTMLRender = DynamicRender{}
+	_ Renderer          = DynamicRender{}
+)
+
+// NewDynamic is the constructor for Dynamic templates
+func NewDynamic() DynamicRender {
+	return make(DynamicRender)
+}
+
+// NewMultitemplateRenderer allows create an agnostic multitemplate renderer
+// depending on enabled gin mode
+func NewMultitemplateRenderer() Renderer {
+	if gin.IsDebugging() {
+		return NewDynamic()
+	}
+	return New()
+}
+
+// Type of dynamic builder
+type builderType int
+
+// Types of dynamic builders
+const (
+	templateType builderType = iota
+	filesTemplateType
+	globTemplateType
+	stringTemplateType
+	stringFuncTemplateType
+	filesFuncTemplateType
+)
+
+// Builder for dynamic templates
+type templateBuilder struct {
+	buildType       builderType
+	tmpl            *template.Template
+	templateName    string
+	files           []string
+	glob            string
+	templateString  string
+	funcMap         template.FuncMap
+	templateStrings []string
+}
+
+func (tb templateBuilder) buildTemplate() *template.Template {
+	switch tb.buildType {
+	case templateType:
+		return tb.tmpl
+	case filesTemplateType:
+		return template.Must(template.ParseFiles(tb.files...))
+	case globTemplateType:
+		return template.Must(template.ParseGlob(tb.glob))
+	case stringTemplateType:
+		return template.Must(template.New(tb.templateName).Parse(tb.templateString))
+	case stringFuncTemplateType:
+		tmpl := template.New(tb.templateName).Funcs(tb.funcMap)
+		for _, ts := range tb.templateStrings {
+			tmpl = template.Must(tmpl.Parse(ts))
+		}
+		return tmpl
+	case filesFuncTemplateType:
+		return template.Must(template.New(tb.templateName).Funcs(tb.funcMap).ParseFiles(tb.files...))
+	default:
+		panic("Invalid builder type for dynamic template")
+	}
+}
+
+// Add new template
+func (r DynamicRender) Add(name string, tmpl *template.Template) {
+	if tmpl == nil {
+		panic("template cannot be nil")
+	}
+	if len(name) == 0 {
+		panic("template name cannot be empty")
+	}
+	builder := &templateBuilder{templateName: name, tmpl: tmpl}
+	r[name] = builder
+}
+
+// AddFromFiles supply add template from files
+func (r DynamicRender) AddFromFiles(name string, files ...string) *template.Template {
+	builder := &templateBuilder{templateName: name, files: files}
+	r[name] = builder
+	return builder.buildTemplate()
+}
+
+// AddFromGlob supply add template from global path
+func (r DynamicRender) AddFromGlob(name, glob string) *template.Template {
+	builder := &templateBuilder{templateName: name, glob: glob}
+	r[name] = builder
+	return builder.buildTemplate()
+}
+
+// AddFromString supply add template from strings
+func (r DynamicRender) AddFromString(name, templateString string) *template.Template {
+	builder := &templateBuilder{templateName: name, templateString: templateString}
+	r[name] = builder
+	return builder.buildTemplate()
+}
+
+// AddFromStringsFuncs supply add template from strings
+func (r DynamicRender) AddFromStringsFuncs(name string, funcMap template.FuncMap, templateStrings ...string) *template.Template {
+	builder := &templateBuilder{templateName: name, funcMap: funcMap,
+		templateStrings: templateStrings}
+	r[name] = builder
+	return builder.buildTemplate()
+}
+
+// AddFromFilesFuncs supply add template from file callback func
+func (r DynamicRender) AddFromFilesFuncs(name string, funcMap template.FuncMap, files ...string) *template.Template {
+	builder := &templateBuilder{templateName: name, funcMap: funcMap, files: files}
+	r[name] = builder
+	return builder.buildTemplate()
+}
+
+// Instance supply render string
+func (r DynamicRender) Instance(name string, data interface{}) render.Render {
+	return render.HTML{
+		Template: r[name].buildTemplate(),
+		Data:     data,
+	}
+}

--- a/dynamic.go
+++ b/dynamic.go
@@ -20,9 +20,9 @@ func NewDynamic() DynamicRender {
 	return make(DynamicRender)
 }
 
-// NewMultitemplateRenderer allows create an agnostic multitemplate renderer
+// NewRenderer allows create an agnostic multitemplate renderer
 // depending on enabled gin mode
-func NewMultitemplateRenderer() Renderer {
+func NewRenderer() Renderer {
 	if gin.IsDebugging() {
 		return NewDynamic()
 	}

--- a/dynamic_test.go
+++ b/dynamic_test.go
@@ -132,14 +132,6 @@ func TestAddFromFilesFruncsDynamic(t *testing.T) {
 	assert.Equal(t, "Welcome to index template\n", w.Body.String())
 }
 
-func TestTestingModeGin(t *testing.T) {
-	gin.SetMode("test")
-	debug := gin.IsDebugging()
-	if debug == true {
-		assert.Equal(t, false, debug)
-	}
-}
-
 func TestPanicInvalidTypeBuilder(t *testing.T) {
 	assert.Panics(t, func() {
 		var b = templateBuilder{}

--- a/dynamic_test.go
+++ b/dynamic_test.go
@@ -1,0 +1,126 @@
+package multitemplate
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func createFromFileDynamic() Renderer {
+	r := NewRenderer()
+	r.AddFromFiles("index", "tests/base.html", "tests/article.html")
+
+	return r
+}
+
+func createFromGlobDynamic() Renderer {
+	r := NewRenderer()
+	r.AddFromGlob("index", "tests/global/*")
+
+	return r
+}
+
+func createFromStringDynamic() Renderer {
+	r := NewRenderer()
+	r.AddFromString("index", "Welcome to {{ .name }} template")
+
+	return r
+}
+
+func createFromStringsWithFuncsDynamic() Renderer {
+	r := NewRenderer()
+	r.AddFromStringsFuncs("index", template.FuncMap{}, `Welcome to {{ .name }} {{template "content"}}`, `{{define "content"}}template{{end}}`)
+
+	return r
+}
+
+func createFromFilesWithFuncsDynamic() Renderer {
+	r := NewRenderer()
+	r.AddFromFilesFuncs("index", template.FuncMap{}, "tests/welcome.html", "tests/content.html")
+
+	return r
+}
+
+func TestMissingTemplateOrNameDynamic(t *testing.T) {
+	r := NewRenderer()
+	tmpl := template.Must(template.New("test").Parse("Welcome to {{ .name }} template"))
+	assert.Panics(t, func() {
+		r.Add("", tmpl)
+	}, "template name cannot be empty")
+
+	assert.Panics(t, func() {
+		r.Add("test", nil)
+	}, "template can not be nil")
+}
+
+func TestAddFromFilesDynamic(t *testing.T) {
+	router := gin.New()
+	router.HTMLRender = createFromFileDynamic()
+	router.GET("/", func(c *gin.Context) {
+		c.HTML(200, "index", gin.H{
+			"title": "Test Multiple Template",
+		})
+	})
+
+	w := performRequest(router, "GET", "/")
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "<p>Test Multiple Template</p>\nHi, this is article template\n", w.Body.String())
+}
+
+func TestAddFromGlobDynamic(t *testing.T) {
+	router := gin.New()
+	router.HTMLRender = createFromGlobDynamic()
+	router.GET("/", func(c *gin.Context) {
+		c.HTML(200, "index", gin.H{
+			"title": "Test Multiple Template",
+		})
+	})
+
+	w := performRequest(router, "GET", "/")
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "<p>Test Multiple Template</p>\nHi, this is login template\n", w.Body.String())
+}
+
+func TestAddFromStringDynamic(t *testing.T) {
+	router := gin.New()
+	router.HTMLRender = createFromStringDynamic()
+	router.GET("/", func(c *gin.Context) {
+		c.HTML(200, "index", gin.H{
+			"name": "index",
+		})
+	})
+
+	w := performRequest(router, "GET", "/")
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "Welcome to index template", w.Body.String())
+}
+
+func TestAddFromStringsFruncsDynamic(t *testing.T) {
+	router := gin.New()
+	router.HTMLRender = createFromStringsWithFuncsDynamic()
+	router.GET("/", func(c *gin.Context) {
+		c.HTML(200, "index", gin.H{
+			"name": "index",
+		})
+	})
+
+	w := performRequest(router, "GET", "/")
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "Welcome to index template", w.Body.String())
+}
+
+func TestAddFromFilesFruncsDynamic(t *testing.T) {
+	router := gin.New()
+	router.HTMLRender = createFromFilesWithFuncsDynamic()
+	router.GET("/", func(c *gin.Context) {
+		c.HTML(200, "index", gin.H{
+			"name": "index",
+		})
+	})
+
+	w := performRequest(router, "GET", "/")
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "Welcome to index template\n", w.Body.String())
+}

--- a/multitemplate.go
+++ b/multitemplate.go
@@ -10,7 +10,10 @@ import (
 // Render type
 type Render map[string]*template.Template
 
-var _ render.HTMLRender = Render{}
+var (
+	_ render.HTMLRender = Render{}
+	_ Renderer          = Render{}
+)
 
 // New instance
 func New() Render {
@@ -43,14 +46,14 @@ func (r Render) AddFromGlob(name, glob string) *template.Template {
 }
 
 // AddFromString supply add template from strings
-func (r *Render) AddFromString(name, templateString string) *template.Template {
+func (r Render) AddFromString(name, templateString string) *template.Template {
 	tmpl := template.Must(template.New(name).Parse(templateString))
 	r.Add(name, tmpl)
 	return tmpl
 }
 
 // AddFromStringsFuncs supply add template from strings
-func (r *Render) AddFromStringsFuncs(name string, funcMap template.FuncMap, templateStrings ...string) *template.Template {
+func (r Render) AddFromStringsFuncs(name string, funcMap template.FuncMap, templateStrings ...string) *template.Template {
 	tmpl := template.New(name).Funcs(funcMap)
 
 	for _, ts := range templateStrings {

--- a/multitemplate.go
+++ b/multitemplate.go
@@ -1,6 +1,7 @@
 package multitemplate
 
 import (
+	"fmt"
 	"html/template"
 	"path/filepath"
 
@@ -27,6 +28,9 @@ func (r Render) Add(name string, tmpl *template.Template) {
 	}
 	if len(name) == 0 {
 		panic("template name cannot be empty")
+	}
+	if _, ok := r[name]; ok {
+		panic(fmt.Sprintf("template %s already exists", name))
 	}
 	r[name] = tmpl
 }

--- a/multitemplate_test.go
+++ b/multitemplate_test.go
@@ -140,3 +140,11 @@ func TestAddFromFilesFruncs(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "Welcome to index template\n", w.Body.String())
 }
+
+func TestDuplicateTemplate(t *testing.T) {
+	assert.Panics(t, func() {
+		r := New()
+		r.AddFromString("index", "Welcome to {{ .name }} template")
+		r.AddFromString("index", "Welcome to {{ .name }} template")
+	})
+}

--- a/renderer.go
+++ b/renderer.go
@@ -1,0 +1,15 @@
+package multitemplate
+
+import "html/template"
+import "github.com/gin-gonic/gin/render"
+
+// Renderer type
+type Renderer interface {
+	render.HTMLRender
+	Add(name string, tmpl *template.Template)
+	AddFromFiles(name string, files ...string) *template.Template
+	AddFromGlob(name, glob string) *template.Template
+	AddFromString(name, templateString string) *template.Template
+	AddFromStringsFuncs(name string, funcMap template.FuncMap, templateStrings ...string) *template.Template
+	AddFromFilesFuncs(name string, funcMap template.FuncMap, files ...string) *template.Template
+}

--- a/renderer.go
+++ b/renderer.go
@@ -3,7 +3,10 @@ package multitemplate
 import "html/template"
 import "github.com/gin-gonic/gin/render"
 
-// Renderer type
+// Renderer type is the Agnostic Renderer for multitemplates.
+// When gin is in debug mode then all multitemplates works with
+// hot reloading allowing you modify file templates and seeing changes instantly.
+// Renderer should be created using multitemplates.NewRederer() constructor.
 type Renderer interface {
 	render.HTMLRender
 	Add(name string, tmpl *template.Template)


### PR DESCRIPTION
While using `gin.LoadHTMLGlob(pattern)` in debug mode you can modify the template file and see the changes instantly.

`multitemplate` package does not have this feature because when you configure it with `multitemplate.AddFromFiles("template", files...)` the templates are create once.

I've created a branch called dynamic-render which provides this feature. I tried to keep it simple and separated of older files. I have copied the unit tests using this feature to make sure it works as expected.

Please maintainers, feel free to give me all tips and corrections if you think I made a mistake with the code or the process of create a pull request.

This would be my very first contribution to an open source project and I really hope this can help to others.

Thanks,
Rodrigo Villablanca