### PR TITLE
fix #28

### DIFF
--- a/dynamic.go
+++ b/dynamic.go
@@ -143,5 +143,6 @@ func (r DynamicRender) Instance(name string, data interface{}) render.Render {
 	return render.HTML{
 		Template: builder.buildTemplate(),
 		Data:     data,
+		Name:     name,
 	}
 }

--- a/multitemplate.go
+++ b/multitemplate.go
@@ -81,5 +81,6 @@ func (r Render) Instance(name string, data interface{}) render.Render {
 	return render.HTML{
 		Template: r[name],
 		Data:     data,
+		Name:     name,
 	}
 }


### PR DESCRIPTION
- dynamic.go do not pass name into render.HTML
- multitemplate do not pass name into render.HTML