### PR TITLE
ci: expand OS support in GitHub Actions workflow for Go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,8 +34,6 @@ jobs:
         include:
           - os: ubuntu-latest
             go-build: ~/.cache/go-build
-          - os: windows-latest
-            go-build: C:\gocache\go-build
           - os: macos-latest
             go-build: ~/Library/Caches/go-build
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,11 +29,15 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         go: [1.21, 1.22, 1.23]
         include:
           - os: ubuntu-latest
             go-build: ~/.cache/go-build
+          - os: windows-latest
+            go-build: C:\gocache\go-build
+          - os: macos-latest
+            go-build: ~/Library/Caches/go-build
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
- Add macOS and Windows to the OS matrix in the GitHub Actions workflow for Go
- Specify Go build cache locations for Windows and macOS