### PR TITLE
Add partial render support using "template#block" syntax (fixes gin-gonic/gin#3745)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,36 @@ func loadTemplates(templatesDir string) multitemplate.Renderer {
   return r
 }
 ```
+
+### Partial render
+
+Allows rendering a specific template/block defined in a file with `template#block` syntax.
+
+See [example/partial/example.go](example/partial/example.go), [htmx ~ Template Fragments](https://htmx.org/essays/template-fragments/)
+
+```go
+func main() {
+	router := gin.Default()
+	router.HTMLRender = createMyRender()
+
+	// Route to render full template
+	router.GET("/", func(c *gin.Context) {
+		c.HTML(200, "index", gin.H{
+			"items": []gin.H{
+				{"name": "Apple"},
+				{"name": "Banana"},
+				{"name": "Cherry"},
+			},
+		})
+	})
+
+	// Route to render partial template using "index#item" syntax
+	router.GET("/item", func(c *gin.Context) {
+		c.HTML(200, "index#item", gin.H{
+			"name": "Watermelon",
+		})
+	})
+
+	router.Run(":8080")
+}
+```

--- a/dynamic.go
+++ b/dynamic.go
@@ -248,12 +248,14 @@ func (r DynamicRender) AddFromFilesFuncsWithOptions(
 
 // Instance supply render string
 func (r DynamicRender) Instance(name string, data interface{}) render.Render {
-	builder, ok := r[name]
+	tmplName, partialName := parseTemplateName(name)
+	builder, ok := r[tmplName]
 	if !ok {
-		panic(fmt.Sprintf("Dynamic template with name %s not found", name))
+		panic(fmt.Sprintf("Dynamic template with name %s not found", tmplName))
 	}
 	return render.HTML{
 		Template: builder.buildTemplate(),
+		Name:     partialName,
 		Data:     data,
 	}
 }

--- a/example/partial/example.go
+++ b/example/partial/example.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"log"
+
+	"github.com/gin-contrib/multitemplate"
+	"github.com/gin-gonic/gin"
+)
+
+func createMyRender() multitemplate.Renderer {
+	r := multitemplate.NewRenderer()
+	r.AddFromFiles("index", "templates/base.html", "templates/item.html")
+	return r
+}
+
+func main() {
+	router := gin.Default()
+	router.HTMLRender = createMyRender()
+
+	// Route to render full template
+	router.GET("/", func(c *gin.Context) {
+		c.HTML(200, "index", gin.H{
+			"items": []gin.H{
+				{"name": "Apple"},
+				{"name": "Banana"},
+				{"name": "Cherry"},
+			},
+		})
+	})
+
+	// Route to render partial template using "index#item" syntax
+	router.GET("/item", func(c *gin.Context) {
+		c.HTML(200, "index#item", gin.H{
+			"name": "Watermelon",
+		})
+	})
+
+	if err := router.Run(":8080"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/example/partial/templates/base.html
+++ b/example/partial/templates/base.html
@@ -1,0 +1,2 @@
+<p>Hello, world</p>
+{{range .items}}{{template "item" .}}{{end}}

--- a/example/partial/templates/item.html
+++ b/example/partial/templates/item.html
@@ -1,0 +1,1 @@
+{{define "item"}}<li>{{.name}} is a good fruit.</li>{{end}}

--- a/multitemplate.go
+++ b/multitemplate.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"io/fs"
 	"path/filepath"
+	"strings"
 
 	"github.com/gin-gonic/gin/render"
 )
@@ -182,8 +183,19 @@ func (r Render) AddFromFilesFuncsWithOptions(
 
 // Instance supply render string
 func (r Render) Instance(name string, data interface{}) render.Render {
+	tmplName, partialName := parseTemplateName(name)
 	return render.HTML{
-		Template: r[name],
+		Template: r[tmplName],
+		Name:     partialName,
 		Data:     data,
 	}
+}
+
+// parseTemplateName parses a template name that may contain a partial reference
+// in the format "template#partial" and returns the template name and partial name
+func parseTemplateName(name string) (templateName, partialName string) {
+	if idx := strings.Index(name, "#"); idx > 0 {
+		return name[:idx], name[idx+1:]
+	}
+	return name, ""
 }

--- a/multitemplate_test.go
+++ b/multitemplate_test.go
@@ -65,6 +65,13 @@ func createFromFilesWithFuncs() Render {
 	return r
 }
 
+func createFromPartial() Render {
+	r := New()
+	r.AddFromFiles("index", "tests/partial/base.html")
+
+	return r
+}
+
 func TestMissingTemplateOrName(t *testing.T) {
 	r := New()
 	tmpl := template.Must(template.New("test").Parse("Welcome to {{ .name }} template"))
@@ -167,4 +174,18 @@ func TestDuplicateTemplate(t *testing.T) {
 		r.AddFromString("index", "Welcome to {{ .name }} template")
 		r.AddFromString("index", "Welcome to {{ .name }} template")
 	})
+}
+
+func TestPartial(t *testing.T) {
+	router := gin.New()
+	router.HTMLRender = createFromPartial()
+	router.GET("/", func(c *gin.Context) {
+		c.HTML(200, "index#item", gin.H{
+			"name": "apple",
+		})
+	})
+
+	w := performRequest(router)
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, "<li>apple</li>", w.Body.String())
 }

--- a/tests/partial/base.html
+++ b/tests/partial/base.html
@@ -1,0 +1,2 @@
+<p>Hello, world</p>
+{{range .items}}{{block "item" .}}<li>{{.name}}</li>{{end}}{{end}}


### PR DESCRIPTION
## Description

As [HTMX](https://htmx.org/) becomes more popular, a page should be able to decide whether to return a **full** response or a **partial** one that updates only part of the view. 

## Current Problem

The current `multitemplate` relies on Gin’s [`c.HTML(code int, name string, obj any)`](https://github.com/gin-gonic/gin/blob/077a2f39c85700ba0823f85ed29cec0c8f2cbdfc/context.go#L1097) signature, which only allows rendering a **whole** "template set", not a specific template/block within "the set".

In [htmx ~ Template Fragments](https://htmx.org/essays/template-fragments), a `template#block` syntax is mentioned. This seems to be a fairly standard convention in template systems.

## Implementation

The change is very simple: it just splits template name from `hello#world` and passes `world` to Gin’s [render.HTML.Name](https://github.com/gin-gonic/gin/blob/077a2f39c85700ba0823f85ed29cec0c8f2cbdfc/render/html.go#L47), basically reusing what we already have.

```go
c.HTML(http.StatusOK, "hello#world", gin.H{
	"fruit": "apple",
})
```

This makes it possible to render partials which is defined as `{{ block "world" . }}` and `{{ define "world" }}` within a template set.

---



related: [[gin-gonic/gin] add partial rendering to context.HTML() or add context.HTMLBlock()](https://github.com/gin-gonic/gin/issues/3745)